### PR TITLE
Add custom 404 page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,12 +2,14 @@ import Link from 'next/link'
 
 export default function NotFound() {
   return (
-    <main className="flex flex-col items-center justify-center min-h-[calc(100vh-100px)] p-4 space-y-4 text-center">
-      <h1 className="text-4xl font-bold">404 - Page Not Found</h1>
-      <img src="/404.png" alt="Not found" className="max-w-xs w-full h-auto" />
-      <p>
-        <Link href="/" className="underline">Return home</Link>
-      </p>
+    <main className="flex flex-col items-center justify-center mt-10 text-center">
+      <Link href="/" className="underline">
+        <>
+          <h1 className="text-4xl font-bold">Page Not Found</h1>
+          <img src="/404.png" alt="Not found" className="max-w-xs w-full h-auto" />
+          <p>Return Home</p>
+        </>
+      </Link>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- display a custom 404 page that links home and shows the 404.png graphic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid Options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)
- `npx eslint app/not-found.tsx`
- `npm run build` (fails: NextFontError: Failed to fetch font `Inter` and `Montserrat`)


------
https://chatgpt.com/codex/tasks/task_e_68bd037ed2f483328254e7dd785a5266