### PR TITLE
feat: add pushups check github action

### DIFF
--- a/.github/workflows/pushups-check.yml
+++ b/.github/workflows/pushups-check.yml
@@ -1,0 +1,9 @@
+name: Pushup Check
+on: [pull_request]
+
+jobs:
+  pushups:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: higgins/gitpushups.com/pushups-action@main

--- a/pushups-action/README.md
+++ b/pushups-action/README.md
@@ -1,0 +1,18 @@
+# Check Git Pushups Action
+
+This composite GitHub Action verifies whether the author of a pull request has completed their daily pushups using the [GitPushups API](https://api.gitpushups.com).
+If the user has not done their pushups for the current day, the action fails the workflow.
+
+## Usage
+
+```yaml
+name: Pushup Check
+on: [pull_request]
+
+jobs:
+  pushups:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: higgins/gitpushups.com/pushups-action@main
+```

--- a/pushups-action/action.yml
+++ b/pushups-action/action.yml
@@ -1,0 +1,18 @@
+name: 'Check Git Pushups'
+description: 'Fails if the pull request author has not completed their daily pushups.'
+author: 'GitPushups'
+runs:
+  using: 'composite'
+  steps:
+    - name: Verify pushups
+      shell: bash
+      run: |
+        AUTHOR="${{ github.event.pull_request.user.login }}"
+        echo "Checking pushups for $AUTHOR"
+        TODAY=$(date -u +%F)
+        RESULT=$(curl -fsSL "https://api.gitpushups.com/user/${AUTHOR}?local_date=${TODAY}" | jq -r '.didPushupsToday')
+        if [[ "$RESULT" != "true" ]]; then
+          echo "::error::$AUTHOR has not done pushups for $TODAY"
+          exit 1
+        fi
+        echo "$AUTHOR has completed their pushups for $TODAY"


### PR DESCRIPTION
## Summary
- add composite GitHub Action to block PRs if author skips pushups
- document action usage for PR workflows

## Testing
- `npm run lint` *(fails: Unknown options useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68c838588f808332b5df68c719c41d0b