### PR TITLE
Fix stats section overflow on mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,8 +92,8 @@ export default async function LandingPage({
         <h3 className="text-3xl font-bold text-black italic mb-0 pb-0">
           The Stats
         </h3>
-        <div className="flex flex-row justify-start items-start">
-          <p className="text-xl">
+        <div className="flex flex-col sm:flex-row justify-start items-center sm:items-start gap-4">
+          <p className="text-xl text-center sm:text-left">
             Developers like you have done...{' '}<br />
             <span className="text-5xl font-bold">
               {typeof totalPushups === 'number'
@@ -103,7 +103,7 @@ export default async function LandingPage({
             </span><br />
             ...and counting!
           </p>
-          <img className="h-36" src="/oneHanded.gif" />
+          <img className="h-36 w-auto max-w-full" src="/oneHanded.gif" />
         </div>
       </section>
       <section id="faq">


### PR DESCRIPTION
## Summary
- update the stats section layout to stack vertically on small screens
- limit the oneHanded.gif image sizing to avoid causing horizontal overflow

## Testing
- npm run lint *(fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc8b6adb4833290f77765a4d25e7b