### PR TITLE
Add GitHub Action option to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ else
 fi
 ```
 
-  Obviously, you're encouraged to block on your own pushups...but it can be fun to do with your coworkers too.
+ Obviously, you're encouraged to block on your own pushups...but it can be fun to do with your coworkers too.
+
+### Or you can configure this GitHub Action to block your Pull Requests
+
+Configure [this GitHub Action](https://github.com/higgins/gitpushups.com/tree/main/pushups-action) to ensure your pull requests are blocked until your pushups are done.
 
 3. **Do pushups or your git hook will fail**
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,6 +82,17 @@ export default async function LandingPage({
           <li className="text-xl">
             Add this rule to your <code>.git/hooks/</code> dir:
             <GitHook />
+            <p className="mt-4">
+              Or configure{' '}
+              <a
+                className="font-bold underline"
+                href="https://github.com/higgins/gitpushups.com/tree/main/pushups-action"
+                target="_blank"
+              >
+                this GitHub Action
+              </a>{' '}
+              to block your pull requests until you get your reps in.
+            </p>
           </li>
           <li className="text-xl">
             Get back to coding! If you don't do pushups everyday, your git-hook will error.


### PR DESCRIPTION
## Summary
- mention the GitHub Action option to enforce pushups alongside the git hook instructions in both the README and landing page

## Testing
- not run (docs/UI copy only)


------
https://chatgpt.com/codex/tasks/task_e_68ccef3828d083329c65c48290a31894